### PR TITLE
Shane/crawler improve url parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+crawler.txt

--- a/crawler.rb
+++ b/crawler.rb
@@ -21,8 +21,7 @@ class Crawler
 		content = UrlFetcher.fetch(url)
 		document = Document.new(url, content)
 		@document_collection.add_document(document)
-		# puts document.domain_hrefs.take(5)
-		puts document.domain_hrefs
+		puts document.domain_hrefs.take(5)
 		document.domain_hrefs.each do |href|
 			@url_collection.add_url(href)
 		end

--- a/crawler.rb
+++ b/crawler.rb
@@ -21,8 +21,9 @@ class Crawler
 		content = UrlFetcher.fetch(url)
 		document = Document.new(url, content)
 		@document_collection.add_document(document)
-		puts document.hrefs.take(5)
-		document.hrefs.each do |href|
+		# puts document.domain_hrefs.take(5)
+		puts document.domain_hrefs
+		document.domain_hrefs.each do |href|
 			@url_collection.add_url(href)
 		end
 	end

--- a/crawler.txt
+++ b/crawler.txt
@@ -1,6 +1,7 @@
-o) filter for domain-specific links only
-o) Test relative urls
+x) filter for domain-specific links only
+x) Test relative urls
 o) create a base class for url collection (what???) and make url_collection an implementation of new base class
+	data_collection? Have noth url and document be implementations of this class?
 o) Handle duplicates across domain
 o) write tests
 

--- a/crawler.txt
+++ b/crawler.txt
@@ -1,3 +1,9 @@
+o) filter for domain-specific links only
+o) Test relative urls
+o) create a base class for url collection (what???) and make url_collection an implementation of new base class
+o) Handle duplicates across domain
+o) write tests
+
 Things the crawler needs to do (methods)
 
 SEED URL = ......
@@ -53,3 +59,32 @@ Nokogiri for parsing and id-ing a-tags
 # 		getting links from the document
 # 	end
 # end
+
+	def dump_content
+		@doc.hrefs.each do |href|
+			@local_copy = '#{DATA_DUMP}/#{File.basename(href)}.html'
+			unless File.exists?(@local_copy)
+				puts "getting #{href}"
+				begin
+					page_content = open(@doc.doc).read
+				rescue Exception=>e
+      		puts "Error: #{e}"
+      		sleep 5
+   			 else
+         	File.open(@local_copy, 'w'){|file| file.write(@doc.doc)}
+        	puts "\t...Success, saved to #{@local_copy}"
+   			 ensure
+      		sleep 1.0 + rand
+      	end
+      end
+		end
+	end
+
+
+
+
+
+
+
+
+

--- a/document.rb
+++ b/document.rb
@@ -7,11 +7,15 @@ class Document
 		@content = content
 	end
 
-	def hrefs
-		@hrefs ||= links.map { |link| link['href'] }.uniq
+	def domain_hrefs
+		@domain_hrefs ||= hrefs.grep (/^\/wiki\//)
 	end
 
 	private
+
+	def hrefs
+		@hrefs ||= links.map { |link| link['href'] }.uniq
+	end
 
 	def parsed
 		@parsed ||= Nokogiri::HTML(@content)

--- a/document.rb
+++ b/document.rb
@@ -9,6 +9,7 @@ class Document
 
 	def domain_hrefs
 		@domain_hrefs ||= hrefs.grep (/^\/wiki\//)
+		@domain_hrefs ||= hrefs.match ('/wiki/')
 	end
 
 	private

--- a/document.rb
+++ b/document.rb
@@ -9,7 +9,6 @@ class Document
 
 	def domain_hrefs
 		@domain_hrefs ||= hrefs.grep (/^\/wiki\//)
-		@domain_hrefs ||= hrefs.match ('/wiki/')
 	end
 
 	private

--- a/document_collection.rb
+++ b/document_collection.rb
@@ -15,4 +15,8 @@ class DocumentCollection
 	def size
 		@arr.size
 	end
+
+	def element(i)
+		@arr[i]
+	end
 end

--- a/document_collection.rb
+++ b/document_collection.rb
@@ -16,7 +16,7 @@ class DocumentCollection
 		@arr.size
 	end
 
-	def element(i)
-		@arr[i]
+	def [](key)
+		@arr[key]
 	end
 end

--- a/script.rb
+++ b/script.rb
@@ -3,12 +3,13 @@ require_relative './crawler'
 require_relative './document_collection'
 require_relative './url_collection'
 
+BASE_URL = 'http://dragonage.wikia.com/'
 document_collection = DocumentCollection.new
 url_collection = UrlCollection.new
-url_collection.add_url('http://dragonage.wikia.com/')
+url_collection.add_url(BASE_URL)
 crawler = Crawler.new(document_collection, url_collection)
 
-crawler.run(3)
+crawler.run(2)
 
 puts document_collection.size
 puts url_collection.size

--- a/script.rb
+++ b/script.rb
@@ -3,17 +3,16 @@ require_relative './crawler'
 require_relative './document_collection'
 require_relative './url_collection'
 
-BASE_URL = 'http://dragonage.wikia.com/'
+BASE_URL = 'http://dragonage.wikia.com'
+
 document_collection = DocumentCollection.new
 url_collection = UrlCollection.new
-url_collection.add_url(BASE_URL)
+url_collection.add_url('')
 crawler = Crawler.new(document_collection, url_collection)
 
-crawler.run(2)
-
+crawler.run(10)
 puts document_collection.size
 puts url_collection.size
-
 
 
 

--- a/url_collection.rb
+++ b/url_collection.rb
@@ -4,7 +4,7 @@ class UrlCollection
 	end
 
 	def next_url
-		@next_url = @arr.shift
+		@next_url = "#{BASE_URL}#{@arr.shift}"
 		@next_url
 	end
 


### PR DESCRIPTION
There were two objectives for this branch:
1) filter for domain-specific links only
2) Test relative urls

I observed that all of the relative urls were domain specific, whereas all other links led off-domain. Thus, there was no need to test the relative urls. Instead, needed to feed only relative urls into the url_collection. All relative links start with "/wiki/", so I used grep to only map links that start with this string to domain_hrefs.

I then created a constant, BASE_URL, as all relative links have a base url of www.dragonage.wikia.com. When fetching a url, I concatenate base url and the scraped url (/wiki/some_page) so that the url fetcher can feed the crawler a valid url.

The crawler successfully runs when fed this concatenated url.